### PR TITLE
Correction English copy

### DIFF
--- a/index_en.html
+++ b/index_en.html
@@ -5,24 +5,24 @@ layout: null
 <html>
 <head>
 	<meta charset="UTF-8">
-	<title>ScalaMatsuri 2016 | The largest class international Scala conference in Asia #ScalaMatsuri</title>
-    <meta name="description" content="The largest class international Scala conference in Asia">
+	<title>ScalaMatsuri 2016 | The largest international Scala conference in Asia #ScalaMatsuri</title>
+    <meta name="description" content="The largest international Scala conference in Asia">
     <meta name="keywords" content="Scala, conference">
 
-    <meta property="og:title" content="ScalaMatsuri 2016 | The largest class international Scala conference in Asia" />
+    <meta property="og:title" content="ScalaMatsuri 2016 | The largest international Scala conference in Asia" />
 	<meta property="og:type" content="website" />
 	<meta property="og:url" content="http://scalamatsuri.org/index_en.html" />
 	<meta property="og:image" content="http://scalamatsuri.org/img/common/img_repre2_en.png" />
-	<meta property="og:site_name" content="ScalaMatsuri 2016｜The largest class international Scala conference in Asia" />
+	<meta property="og:site_name" content="ScalaMatsuri 2016｜The largest international Scala conference in Asia" />
 	<meta property="og:locale" content="en_US" />
-	<meta property="og:description" content="The largest class international Scala conference in Asia" />
+	<meta property="og:description" content="The largest international Scala conference in Asia" />
 
     <meta name="twitter:card" content="summary_large_image">
 	<meta name="twitter:site" content="">
 	<meta name="twitter:creator" content="">
 	<meta name="twitter:url" content="http://scalamatsuri.org/">
-	<meta name="twitter:title" content="ScalaMatsuri 2016｜The largest class international Scala conference in Asia">
-	<meta name="twitter:description" content="The largest class international Scala conference in Asia">
+	<meta name="twitter:title" content="ScalaMatsuri 2016｜The largest international Scala conference in Asia">
+	<meta name="twitter:description" content="The largest international Scala conference in Asia">
 	<meta name="twitter:image" content="http://scalamatsuri.org/img/common/img_repre2_en.png">
 
     <link href="css/common.css" rel="stylesheet" type="text/css">
@@ -176,7 +176,7 @@ layout: null
 				<p class="timeData">
 					30th - 31st January, in Tokyo</p>
 				<p class="txtData">
-					The largest class international Scala conference in Asia</p>
+					The largest international Scala conference in Asia</p>
 				<div class="logoArea">
 					<h2 class="clearfix">
 						&nbsp; <!-- <- スポンサーコメントイン時に消す


### PR DESCRIPTION
Correction of English copy. "The largest _class_ international Scala..." doesn't make a lot of sense
