### PR TITLE
コンテンツページ用のヘッダ

### DIFF
--- a/_includes/header_en.html
+++ b/_includes/header_en.html
@@ -1,0 +1,22 @@
+<header class="pageHeader">
+  <nav class="gnav navbar">
+    <div class="navbar-header">
+      <a class="navbar-brand" href="/index_en.html">
+        ScalaMatsuri 2016
+      </a>
+    </div>
+    <ul class="clearfix">
+      <li><a href="/index_en.html#info">Event Info</a></li>
+
+      <li><a href="/en/cfp/">CFP</a></li>
+      <li><a href="/en/candidates/">Proposal List</a></li>
+      <!--
+      <li><a href="#gues">招待講演者</a></li>
+      <li><a href="#prog">プログラム</a></li>
+      <li><a href="#inq">お申込み</a></li>
+      <li><a href="#sp">スポンサー</a></li>
+      -->
+      <li><a href="/">日本語</a></li>
+    </ul>
+  </nav>
+</header>

--- a/_includes/header_ja.html
+++ b/_includes/header_ja.html
@@ -1,0 +1,22 @@
+<header class="pageHeader">
+  <nav class="gnav navbar">
+    <div class="navbar-header">
+      <a class="navbar-brand" href="/">
+        ScalaMatsuri 2016
+      </a>
+    </div>
+    <ul class="clearfix">
+      <li><a href="/#info">開催概要</a></li>
+
+      <li><a href="/ja/cfp/">セッション募集</a></li>
+      <li><a href="/ja/candidates/">応募セッション一覧</a></li>
+      <!--
+      <li><a href="#gues">招待講演者</a></li>
+      <li><a href="#prog">プログラム</a></li>
+      <li><a href="#inq">お申込み</a></li>
+      <li><a href="#sp">スポンサー</a></li>
+      -->
+      <li><a href="/index_en.html">English</a></li>
+    </ul>
+  </nav>
+</header>

--- a/_layouts/default_en.html
+++ b/_layouts/default_en.html
@@ -25,16 +25,8 @@
     <![endif]-->
   </head>
   <body>
-    <nav class="navbar navbar-default">
-      <div class="container main-container">
-        <div class="navbar-header">
-          <a class="navbar-brand" href="/index_en.html">
-            ScalaMatsuri 2016
-          </a>
-        </div>
-      </div>
-    </nav>
-    <div class="container">
+    {% include header_en.html %}
+    <div class="container main-container">
       {{ content }}
     </div>
     {% include footer.html %}

--- a/_layouts/default_ja.html
+++ b/_layouts/default_ja.html
@@ -25,15 +25,7 @@
     <![endif]-->
   </head>
   <body>
-    <nav class="navbar navbar-default">
-      <div class="container">
-        <div class="navbar-header">
-          <a class="navbar-brand" href="/">
-            ScalaMatsuri 2016
-          </a>
-        </div>
-      </div>
-    </nav>
+    {% include header_ja.html %}
     <div class="container main-container">
       {{ content }}
     </div>

--- a/css/extra.scss
+++ b/css/extra.scss
@@ -14,6 +14,52 @@ body {
   /* Space between body and footer */
   padding-bottom: 40px;
 }
+
+.pageHeader {
+  position: fixed;
+  width: 100%;
+  background-color: rgba( 0, 0, 0, 0.80 );
+  z-index:9999;
+}
+
+.pageHeader .navbar {
+  margin: 0px;
+}
+
+.pageHeader .navbar a {
+  color:#fff;
+  text-decoration: none;
+}
+
+
+.pageHeader ul {
+  padding: 12px 0 0px 0;
+  text-align: center;
+  margin: 0px;
+}
+
+.pageHeader ul li{
+  font-size: 12px;
+  display:inline;
+  padding-left:5px;
+  padding-right:5px;
+  margin: 0px;
+  font-size:14px;
+}
+
+.pageHeader ul li a{
+  color:#fff;
+  text-decoration: none;
+}
+
+.pageHeader ul li a:hover{
+  color:#cf293b;
+}
+
+.main-container {
+  padding-top: 4.5em;
+}
+
 .mainFooter {
   position: absolute;
   bottom: 0;


### PR DESCRIPTION
トップページのような半透明 fixed なヘッダをコンテンツページ用のレイアウトにも追加しました。

<img width="956" alt="scalamatsuri_2016" src="https://cloud.githubusercontent.com/assets/184683/9157388/9d1282f2-3ec9-11e5-9366-132c09750993.png">
