### PR TITLE
Doorkeeperウィジェットをリンクに変更

### DIFF
--- a/index.html
+++ b/index.html
@@ -782,7 +782,7 @@ layout: null
 				<p class="subTtlSm">Tickets</p>
 			</header>
 			<div class="inqBox">
-				<a data-width="300" class="doorkeeper-registration-widget" href="https://scalaconfjp.doorkeeper.jp/events/31702">ScalaMatsuri 2016</a><script src="http://widgets.doorkeeper.jp/w/widget.js"></script>
+				<a href="https://scalaconfjp.doorkeeper.jp/events/31702">ScalaMatsuri 2016</a>
 			</div>
 		</section>
 

--- a/index_en.html
+++ b/index_en.html
@@ -785,7 +785,7 @@ We are looking for topics that you think Scala community would be interested. We
 				<p class="subTtlSm"></p>
 			</header>
 			<div class="inqBox">
-				<a data-width="300" class="doorkeeper-registration-widget" href="https://scalaconfjp.doorkeeper.jp/events/31702">ScalaMatsuri 2016</a><script src="http://widgets.doorkeeper.jp/w/widget.js"></script>
+				<a href="https://scalaconfjp.doorkeeper.jp/events/31702">ScalaMatsuri 2016</a>
 			</div>
 		</section>
 


### PR DESCRIPTION
注意書き(CoCの同意等)が目に触れない導線になってしまっているので、チケット販売ページへのリンクに変更

see https://github.com/scalajp/2015/issues/420#issuecomment-144594581
