### PR TITLE
Ensure GA is loaded before tracking outbound links

### DIFF
--- a/_includes/ga.html
+++ b/_includes/ga.html
@@ -30,7 +30,7 @@
     // Track all clicks of outbound link
     $(document).on('click', 'a', function(event) {
       var href = $(event.currentTarget).attr('href');
-      if (isOutbound(href)) {
+      if (ga.loaded && isOutbound(href)) {
         var gaaction = $(event.currentTarget).data('gaaction');
         trackOutboundLink(href, gaaction);
         event.preventDefault();


### PR DESCRIPTION
Workaround suggested by https://www.domsammut.com/code/workaround-for-when-the-hitcallback-function-does-not-receive-a-response-analytics-js

Fixes #197 
