### PR TITLE
Constant candidates order in a browser session

### DIFF
--- a/en/candidates/index.html
+++ b/en/candidates/index.html
@@ -15,7 +15,7 @@ layout: default_en
 </div>
 
 <h2>40-minute sessions in English</h2>
-<div class="shuffle">
+<div class="shuffle-session">
 {% assign has_40en = false %}
 {% for candidate in site.candidates_en %}
   {% if candidate.length == 40 and candidate.language == "English" %}
@@ -29,7 +29,7 @@ layout: default_en
 {% endunless %}
 
 <h2>40-minute sessions in Japanese</h2>
-<div class="shuffle">
+<div class="shuffle-session">
 {% assign has_40ja = false %}
 {% for candidate in site.candidates_en %}
   {% if candidate.length == 40 and candidate.language != "English" %}
@@ -43,7 +43,7 @@ layout: default_en
 {% endunless %}
 
 <h2>15-minute sessions in English</h2>
-<div class="shuffle">
+<div class="shuffle-session">
 {% assign has15_en = false %}
 {% for candidate in site.candidates_en %}
   {% if candidate.length == 15 and candidate.language == "English" %}
@@ -57,7 +57,7 @@ layout: default_en
 {% endunless %}
 
 <h2>15-minute sessions in Japanese</h2>
-<div class="shuffle">
+<div class="shuffle-session">
 {% assign has15_ja = false %}
 {% for candidate in site.candidates_en %}
   {% if candidate.length == 15 and candidate.language != "English" %}

--- a/ja/candidates/index.html
+++ b/ja/candidates/index.html
@@ -15,7 +15,7 @@ title: 応募セッション一覧
 </div>
 
 <h2>40分英語</h2>
-<div class="shuffle">
+<div class="shuffle-session">
 {% assign has_40en = false %}
 {% for candidate in site.candidates_ja %}
   {% if candidate.length == 40 and candidate.language == "English" %}
@@ -29,7 +29,7 @@ title: 応募セッション一覧
 {% endunless %}
 
 <h2>40分日本語</h2>
-<div class="shuffle">
+<div class="shuffle-session">
 {% assign has_40ja = false %}
 {% for candidate in site.candidates_ja %}
   {% if candidate.length == 40 and candidate.language != "English" %}
@@ -43,7 +43,7 @@ title: 応募セッション一覧
 {% endunless %}
 
 <h2>15分英語</h2>
-<div class="shuffle">
+<div class="shuffle-session">
 {% assign has15_en = false %}
 {% for candidate in site.candidates_ja %}
   {% if candidate.length == 15 and candidate.language == "English" %}
@@ -57,7 +57,7 @@ title: 応募セッション一覧
 {% endunless %}
 
 <h2>15分日本語</h2>
-<div class="shuffle">
+<div class="shuffle-session">
 {% assign has15_ja = false %}
 {% for candidate in site.candidates_ja %}
   {% if candidate.length == 15 and candidate.language != "English" %}

--- a/js/shuffle.js
+++ b/js/shuffle.js
@@ -11,19 +11,48 @@
  * This uses the Fisher-Yates shuffle algorithm <http://jsfromhell.com/array/shuffle [v1.0]>
  */
 (function($){
-  $.fn.shuffle = function() {
+  $.fn.shuffle = function(random) {
+    if (typeof random !== 'function') {
+      random = Math.random;
+    }
     return this.each(function(){
       var items = $(this).children();
       return (items.length)
-        ? $(this).html($.shuffle(items))
+        ? $(this).html($.shuffle(items, random))
         : this;
     });
   }
 
-  $.shuffle = function(arr) {
+  // ref. http://stackoverflow.com/a/19303725/339515
+  $.seededRandom = function(seed) {
+    return function() {
+      var x = Math.sin(seed++) * 10000;
+      return x - Math.floor(x);
+    };
+  };
+
+  $.getSessionSeed = function() {
+    function load() {
+      return /SM_RAND_SEED=([^;]+)/.test(document.cookie) ? RegExp.$1 : null;
+    }
+    function save(seed) {
+      document.cookie = "SM_RAND_SEED=" + seed + ";path=/";
+    }
+
+    var loaded = load();
+    // There's no seed in cookie. Generate one.
+    if (loaded == null) {
+      save(String(Math.random()));
+      loaded = load();
+    }
+    // loaded might be null if cookie is disabled.
+    return loaded == null ? 0 : Number(loaded);
+  };
+
+  $.shuffle = function(arr, random) {
     for(
       var j, x, i = arr.length; i;
-      j = parseInt(Math.random() * i),
+      j = parseInt(random() * i),
       x = arr[--i], arr[i] = arr[j], arr[j] = x
     );
     return arr;
@@ -32,4 +61,5 @@
 
 $(function() {
   $(".shuffle").shuffle();
+  $(".shuffle-session").shuffle($.seededRandom($.getSessionSeed()));
 });


### PR DESCRIPTION
ブラウザのセッションが続く間、応募一覧が同じソート順になるようにします。これによりページ遷移時の混乱がだいぶ収まると思います。(#61)

意図していなかったのですが、嬉しい副作用として日本語のリストと英語のリストを見た時に同じ順になりました（日英でファイルリストが同じ時）。

いままで `shuffle` CSSクラスをつけるとその下の DOM 要素を毎度シャッフルしていましたが、新しく作った `shuffle-session` CSSクラスをつけると、ブラウザセッションのたびにシャッフルします。

Fixes #61
