### PR TITLE
generate schedule entry from YAML

### DIFF
--- a/_includes/schedule_en.html
+++ b/_includes/schedule_en.html
@@ -1,0 +1,17 @@
+{% capture relative_path %}_candidates_en/{{include.id}}.html{% endcapture %}
+{% for candidate in site.candidates_en %}
+  {% if candidate.relative_path == relative_path %}
+    <span class="session_title">{{ candidate.title }}</span>
+    <span class="session_name">
+      {% if candidate.icon %}
+        <img src="{{ candidate.icon }}" class="icon-mini">
+      {% endif %}
+      {{ candidate.name }}
+    </span>
+    {% if candidate.twitter %}
+    <a href="https://twitter.com/{{ candidate.twitter }}">@{{ candidate.twitter }}</a>
+    {% endif %}
+    <span class="session_details">{% if candidate.language == "Japanese" %}J{% else %}E{% endif %}{% if candidate.audience == "Beginner" %}+{% elsif candidate.audience == "Intermediate" %}++{% else %}+++{% endif %}
+    </span>
+  {% endif %}
+{% endfor %}

--- a/_includes/schedule_ja.html
+++ b/_includes/schedule_ja.html
@@ -1,0 +1,17 @@
+{% capture relative_path %}_candidates_ja/{{include.id}}.html{% endcapture %}
+{% for candidate in site.candidates_ja %}
+  {% if candidate.relative_path == relative_path %}
+    <span class="session_title">{{ candidate.title }}</span>
+    <span class="session_name">
+      {% if candidate.icon %}
+        <img src="{{ candidate.icon }}" class="icon-mini">
+      {% endif %}
+      {{ candidate.name }}
+    </span>
+    {% if candidate.twitter %}
+    <a href="https://twitter.com/{{ candidate.twitter }}">@{{ candidate.twitter }}</a>
+    {% endif %}
+    <span class="session_details">{% if candidate.language == "Japanese" %}J{% else %}E{% endif %}{% if candidate.audience == "Beginner" %}+{% elsif candidate.audience == "Intermediate" %}++{% else %}+++{% endif %}
+    </span>
+  {% endif %}
+{% endfor %}

--- a/css/common.css
+++ b/css/common.css
@@ -767,6 +767,10 @@ span.session_title {
 	color: black;
 }
 
+.icon-mini { height: 30px; width: 30px; }
+
+.icon-medium { height: 50px; width: 50px; }
+
 @media screen and (max-width: 1024px){
 
 	.snsBtnArea{

--- a/index.html
+++ b/index.html
@@ -349,8 +349,7 @@ layout: null
 								<th>10:00 - 10:40</th>
 								<td class="roomA">
 									<span class="session_id">A-1</span>
-									<span class="session_title">Refactoring in Scala</span>
-									<span class="session_details">中村 学 (がくぞ) J++</span>
+									{% include schedule_ja.html id="ManabuNakamura_1" %}
 								</td>
 								<td class="roomB">&nbsp;</td>
 								<td class="roomC">&nbsp;</td>
@@ -363,18 +362,15 @@ layout: null
 								<th>11:00 - 11:40</th>
 								<td class="roomA">
 									<span class="session_id">A-2</span>
-									<span class="session_title">なぜリアクティブは重要か</span>
-									<span class="session_details">岡本 雄太 J++</span>
+									{% include schedule_ja.html id="YutaOkamoto_1" %}
 								</td>
 								<td class="roomB">
 									<span class="session_id">B-2</span>
-									<span class="session_title">型 vs テスト</span>
-									<span class="session_details">Amanda Laucher E++</span>
+									{% include schedule_ja.html id="AmandaLaucher_1" %}
 								</td>
 								<td class="roomC">
 									<span class="session_id">C-2</span>
-									<span class="session_title">Scalaで始めるDeep Learning</span>
-									<span class="session_details">麻植泰輔 J+</span>
+									{% include schedule_ja.html id="TaisukeOe_1" %}
 								</td>
 							</tr>
 							<tr>
@@ -385,18 +381,16 @@ layout: null
 								<th>12:00 - 12:40</th>
 								<td class="roomA">
 									<span class="session_id">A-3</span>
-									<span class="session_title">リアクティブ・マイクロサービス</span>
-									<span class="session_details">Christopher Hunt E++</span>
+									{% include schedule_ja.html id="ChristopherHunt_1" %}
 								</td>
 								<td class="roomB">
 									<span class="session_id">B-3</span>
-									<span class="session_title">楽しく役立つ Scala リファクタリング</span>
-									<span class="session_details">Tomer Gabel E++</span>
+									{% include schedule_ja.html id="TomerGabel_1" %}
 								</td>
 								<td class="roomC">
 									<span class="session_id">C-3</span>
-									<span class="session_title">猫という考え方</span>
-									<span class="session_details">Eugene Yokota J++</span>
+									{% include schedule_ja.html id="EugeneYokota_1" %}
+								</td>
 							</tr>
 							<tr>
 								<th>12:40 - 13:40</th>
@@ -406,13 +400,11 @@ layout: null
 								<th>13:40 - 13:55</th>
 								<td class="roomA">
 									<span class="session_id">S-1</span>
-									<span class="session_title">バッチを Akka Streams で再実装したら100倍速くなった話</span>
-									<span class="session_details">根来 和輝 J++</span>
+									{% include schedule_ja.html id="KazukiNegoro_1" %}
 								</td>
 								<td class="roomB">
 									<span class="session_id">T-1</span>
-									<span class="session_title">Dockerをベースとしたインフラ上でのPlay frameworkアプリケーション本番運用ノウハウ</span>
-									<span class="session_details">Naoki Ainoya E++</span>
+									{% include schedule_ja.html id="NaokiAinoya_1" %}
 								</td>
 								<td class="roomC">&nbsp;</td>
 							</tr>
@@ -420,13 +412,11 @@ layout: null
 								<th>14:05 - 14:20</th>
 								<td class="roomA">
 									<span class="session_id">S-2</span>
-									<span class="session_title">sbt-awsプラグインを使って簡単デプロイ</span>
-									<span class="session_details">かとじゅん J+++</span>
+									{% include schedule_ja.html id="JunichiKato_1" %}
 								</td>
 								<td class="roomB">
 									<span class="session_id">T-2</span>
-									<span class="session_title">アジアから Scala OSS に貢献するということ</span>
-									<span class="session_details">Kazuhiro Sera E++</span>
+									{% include schedule_ja.html id="KazuhiroSera_1" %}
 								</td>
 								<td class="roomC">&nbsp;</td>
 							</tr>
@@ -434,13 +424,11 @@ layout: null
 								<th>14:30 - 14:45</th>
 								<td class="roomA">
 									<span class="session_id">S-3</span>
-									<span class="session_title">ScalaコードはJVMでどのように表現されているのか</span>
-									<span class="session_details">阪田 浩一 J+</span>
+									{% include schedule_ja.html id="KoichiSakata_1" %}
 								</td>
 								<td class="roomB">
 									<span class="session_id">T-3</span>
-									<span class="session_title">みんなの関数型プログラミング</span>
-									<span class="session_details">Zach McCoy E+</span>
+									{% include schedule_ja.html id="ZachMcCoy_1" %}
 								</td>
 								<td class="roomC">&nbsp;</td>
 							</tr>
@@ -452,8 +440,7 @@ layout: null
 								<th>15:00 - 15:40</th>
 								<td class="roomA">
 									<span class="session_id">A-4</span>
-									<span class="session_title">実用関数型アーキテクチャのパターン</span>
-									<span class="session_details">Raul Raja E++</span>
+									{% include schedule_ja.html id="RaulRaja_1" %}
 								</td>
 								<td class="roomB">
 									<span class="session_id">B-4</span>
@@ -461,8 +448,7 @@ layout: null
 								</td>
 								<td class="roomC">
 									<span class="session_id">C-4</span>
-									<span class="session_title">あなたのScalaを爆速にする７つの方法</span>
-									<span class="session_details">井上 ゆり J+</span>
+									{% include schedule_ja.html id="YuriInoue_1" %}
 								</td>
 							</tr>
 							<tr>
@@ -473,18 +459,15 @@ layout: null
 								<th>16:00 - 16:40</th>
 								<td class="roomA">
 									<span class="session_id">A-5</span>
-									<span class="session_title">関数型、代数的なドメイン・モデリングの方法</span>
-									<span class="session_details">Debasish Ghosh E+++</span>
+									{% include schedule_ja.html id="DebasishGhosh_1" %}
 								</td>
 								<td class="roomB">
 									<span class="session_id">B-5</span>
-									<span class="session_title">The Zen of Akka</span>
-									<span class="session_details">Konrad Malawski E++</span>
+									{% include schedule_ja.html id="KonradMalawski_2" %}
 								</td>
 								<td class="roomC">
 									<span class="session_id">C-5</span>
-									<span class="session_title">Playソースコード完全マスターへの道</span>
-									<span class="session_details">高橋俊幸 J++</span>
+									{% include schedule_ja.html id="TakahashiToshiyuki_1" %}
 								</td>
 							</tr>
 							<tr>
@@ -495,18 +478,15 @@ layout: null
 								<th>17:10 - 17:50</th>
 								<td class="roomA">
 									<span class="session_id">A-6</span>
-									<span class="session_title">ドワンゴアカウントシステムを支えるScala技術</span>
-									<span class="session_details">結城清太郎 J++</span>
+									{% include schedule_ja.html id="SeitaroYuuki_1" %}
 								</td>
 								<td class="roomB">
 									<span class="session_id">B-6</span>
-									<span class="session_title">実戦Scalaz-Stream: 既存のバッチシステムを置き換える</span>
-									<span class="session_details">Mathias Sulser E++</span>
+									{% include schedule_ja.html id="MathiasSulser_1" %}
 								</td>
 								<td class="roomC">
 									<span class="session_id">C-6</span>
-									<span class="session_title">Scalaでドメイン駆動設計に真正面から取り組んだ話</span>
-									<span class="session_details">藤井 善隆 J++</span>
+									{% include schedule_ja.html id="YoshitakaFujii_1" %}
 								</td>
 							</tr>
 							<tr>
@@ -566,8 +546,7 @@ layout: null
 								<td class="roomA">TBD</td>
 								<td class="roomB">
 									<span class="session_id">B-2</span>
-									<span class="session_title">ScalaとSparkによる日本語テキストマイニング</span>
-									<span class="session_details">Eduardo Gonzalez J+</span>
+									{% include schedule_ja.html id="EduardoGonzalez_1" %}
 								</td>
 								<td class="roomC">TBD</td>
 							</tr>
@@ -582,8 +561,7 @@ layout: null
 								<td class="roomA">TBD</td>
 								<td class="roomB">
 									<span class="session_id">B-3</span>
-									<span class="session_title">正常系の末に行き着く異常さ</span>
-									<span class="session_details">Jonas Bonér E++</span>
+									{% include schedule_ja.html id="JonasBoner_2" %}
 								</td>
 								<td class="roomC">TBD</td>
 							</tr>
@@ -596,8 +574,7 @@ layout: null
 								<td class="roomA">TBD</td>
 								<td class="roomB">
 									<span class="session_id">B-4</span>
-									<span class="session_title">IntelliJ IDEA で Scala をマスターする</span>
-									<span class="session_details">Alexander Podkhalyuzin E+</span>
+									{% include schedule_ja.html id="AlexanderPodkhalyuzin_1" %}
 								</td>
 								<td class="roomC">TBD</td>
 							</tr>
@@ -610,8 +587,7 @@ layout: null
 								<td class="roomA">TBD</td>
 								<td class="roomB">
 									<span class="session_id">B-5</span>
-									<span class="session_title">Scala.js コンパイル・パイプライン</span>
-									<span class="session_details">Tobias Schlatter E+++</span>
+									{% include schedule_ja.html id="TobiasSchlatter_1" %}
 								</td>
 								<td class="roomC">TBD</td>
 							</tr>

--- a/index_en.html
+++ b/index_en.html
@@ -344,8 +344,7 @@ layout: null
 								<th>10:00 - 10:40</th>
 								<td class="roomA">
 									<span class="session_id">A-1</span>
-									<span class="session_title">Refactoring in Scala</span>
-									<span class="session_details">Manabu Nakamura J++</span>
+									{% include schedule_en.html id="ManabuNakamura_1" %}
 								</td>
 								<td class="roomB">&nbsp;</td>
 								<td class="roomC">&nbsp;</td>
@@ -358,16 +357,15 @@ layout: null
 								<th>11:00 - 11:40</th>
 								<td class="roomA">
 									<span class="session_id">A-2</span>
-									<span class="session_title">Why Reactive Matters</span>
-									<span class="session_details">Yuta Okamoto J++</td>
+									{% include schedule_en.html id="YutaOkamoto_1" %}
 								<td class="roomB">
 									<span class="session_id">B-2</span>
-									<span class="session_title">Types vs Tests</span>
-									<span class="session_details">Amanda Laucher E++</td>
+									{% include schedule_en.html id="AmandaLaucher_1" %}
+								</td>
 								<td class="roomC">
 									<span class="session_id">C-2</span>
-									<span class="session_title">Getting started with DeepLearning using Scala</span>
-									<span class="session_details">Taisuke Oe J+</td>
+									{% include schedule_en.html id="TaisukeOe_1" %}
+								</td>
 							</tr>
 							<tr>
 								<th>11:40 - 12:00</th>
@@ -377,16 +375,16 @@ layout: null
 								<th>12:00 - 12:40</th>
 								<td class="roomA">
 									<span class="session_id">A-3</span>
-									<span class="session_title">Reactive Microservices</span>
-									<span class="session_details">Christopher Hunt E++</td>
+									{% include schedule_en.html id="ChristopherHunt_1" %}
+								</td>
 								<td class="roomB">
 									<span class="session_id">B-3</span>
-									<span class="session_title">Scala Refactoring for Fun and Profit</span>
-									<span class="session_details">Tomer Gabel E++</td>
+									{% include schedule_en.html id="TomerGabel_1" %}
+								</td>
 								<td class="roomC">
 									<span class="session_id">C-3</span>
-									<span class="session_title">Thinking in Cats</span>
-									<span class="session_details">Eugene Yokota J++</td>
+									{% include schedule_en.html id="EugeneYokota_1" %}
+								</td>
 							</tr>
 							<tr>
 								<th>12:40 - 13:40</th>
@@ -396,36 +394,34 @@ layout: null
 								<th>13:40 - 13:55</th>
 								<td class="roomA">
 									<span class="session_id">S-1</span>
-									<span class="session_title">100x speedup by re-implementing batch processing with Akka Streams</span>
-									<span class="session_details">Kazuki Negoro J++</td>
+									{% include schedule_en.html id="KazukiNegoro_1" %}
+								</td>
 								<td class="roomB">
 									<span class="session_id">T-1</span>
-									<span class="session_title">How to Play Scala production framework on Dockerized Infrastructure</span>
-									<span class="session_details">Naoki Ainoya E++</td>
+									{% include schedule_en.html id="NaokiAinoya_1" %}
+								</td>
 								<td class="roomC">&nbsp;</td>
 							</tr>
 							<tr>
 								<th>14:05 - 14:20</th>
 								<td class="roomA">
 									<span class="session_id">S-2</span>
-									<span class="session_title">Easy deployment with sbt-aws plugin</span>
-									<span class="session_details">Junichi Kato J+++</td>
+									{% include schedule_en.html id="JunichiKato_1" %}
 								<td class="roomB">
 									<span class="session_id">T-2</span>
-									<span class="session_title">Contributing to Scala OSS from East Asia</span>
-									<span class="session_details">Kazuhiro Sera E++</td>
+									{% include schedule_en.html id="KazuhiroSera_1" %}
 								<td class="roomC">&nbsp;</td>
 							</tr>
 							<tr>
 								<th>14:30 - 14:45</th>
 								<td class="roomA">
 									<span class="session_id">S-3</span>
-									<span class="session_title">How Scala code is expressed in the JVM</span>
-									<span class="session_details">Koichi Sakata J+</td>
+									{% include schedule_en.html id="KoichiSakata_1" %}
+								</td>
 								<td class="roomB">
 									<span class="session_id">T-3</span>
-									<span class="session_title">Functional Programming for All</span>
-									<span class="session_details">Zach McCoy E+</td>
+									{% include schedule_en.html id="ZachMcCoy_1" %}
+								</td>
 								<td class="roomC">&nbsp;</td>
 							</tr>
 							<tr>
@@ -436,16 +432,14 @@ layout: null
 								<th>15:00 - 15:40</th>
 								<td class="roomA">
 									<span class="session_id">A-4</span>
-									<span class="session_title">Patterns of a pragmatic functional architecture</span>
-									<span class="session_details">Raul Raja E++</span>
+									{% include schedule_en.html id="RaulRaja_1" %}
 								</td>
 								<td class="roomB">
 									<span class="session_id">B-4</span>
 									TBA</td>
 								<td class="roomC">
 									<span class="session_id">C-4</span>
-									<span class="session_title">7 ways to make your Scala red-hot high velocity</span>
-									<span class="session_details">iyunoriue(x1) J+</span>
+									{% include schedule_en.html id="YuriInoue_1" %}
 								</td>
 							</tr>
 							<tr>
@@ -456,18 +450,15 @@ layout: null
 								<th>16:00 - 16:40</th>
 								<td class="roomA">
 									<span class="session_id">A-5</span>
-									<span class="session_title">A Functional and Algebraic Approach to Domain Modeling</span>
-									<span class="session_details">Debasish Ghosh E+++</span>
+									{% include schedule_en.html id="DebasishGhosh_1" %}
 								</td>
 								<td class="roomB">
 									<span class="session_id">B-5</span>
-									<span class="session_title">The Zen of Akka</span>
-									<span class="session_details">Konrad Malawski E++</span>
+									{% include schedule_en.html id="KonradMalawski_2" %}
 								</td>
 								<td class="roomC">
 									<span class="session_id">C-5</span>
-									<span class="session_title">Steps to master the Play source code</span>
-									<span class="session_details">Toshiyuki Takahashi J++</span>
+									{% include schedule_en.html id="TakahashiToshiyuki_1" %}
 								</td>
 							</tr>
 							<tr>
@@ -478,18 +469,15 @@ layout: null
 								<th>17:10 - 17:50</th>
 								<td class="roomA">
 									<span class="session_id">A-6</span>
-									<span class="session_title">Scala technology supporting the Dwango Account system</span>
-									<span class="session_details">Seitaro Yuuki J++</span>
+									{% include schedule_en.html id="SeitaroYuuki_1" %}
 								</td>
 								<td class="roomB">
 									<span class="session_id">B-6</span>
-									<span class="session_title">Scalaz-Stream in the Wild: Rearchitecting Existing Batch Applications</span>
-									<span class="session_details">Mathias Sulser E++</span>
+									{% include schedule_en.html id="MathiasSulser_1" %}
 								</td>
 								<td class="roomC">
 									<span class="session_id">C-6</span>
-									<span class="session_title">Heads-on Domain Driven Development in Scala</span>
-									<span class="session_details">Yoshitaka Fujii J++</span>
+									{% include schedule_en.html id="YoshitakaFujii_1" %}
 								</td>
 							</tr>
 							<tr>
@@ -550,8 +538,7 @@ layout: null
 								<td class="roomA">TBD</td>
 								<td class="roomB">
 									<span class="session_id">B-2</span>
-									<span class="session_title">Japanese Text Mining with Scala and Spark</span>
-									<span class="session_details">Eduardo Gonzalez J+</span>
+									{% include schedule_en.html id="EduardoGonzalez_1" %}
 								</td>
 								<td class="roomC">TBD</td>
 							</tr>
@@ -566,8 +553,7 @@ layout: null
 								<td class="roomA">TBD</td>
 								<td class="roomB">
 									<span class="session_id">B-3</span>
-									<span class="session_title">The Sadness at the End of the Happy Path</span>
-									<span class="session_details">Jonas Bonér E++</span>
+									{% include schedule_en.html id="JonasBoner_2" %}
 								</td>
 								<td class="roomC">TBD</td>
 							</tr>
@@ -580,8 +566,7 @@ layout: null
 								<td class="roomA">TBD</td>
 								<td class="roomB">
 									<span class="session_id">B-4</span>
-									<span class="session_title">Mastering Scala with IntelliJ IDEA</span>
-									<span class="session_details">Alexander Podkhalyuzin E+</span>
+									{% include schedule_en.html id="AlexanderPodkhalyuzin_1" %}
 								</td>
 								<td class="roomC">TBD</td>
 							</tr>
@@ -594,8 +579,7 @@ layout: null
 								<td class="roomA">TBD</td>
 								<td class="roomB">
 									<span class="session_id">B-5</span>
-									<span class="session_title">The Scala.js Compilation Pipeline</span>
-									<span class="session_details">Tobias Schlatter E+++</span>
+									{% include schedule_en.html id="TobiasSchlatter_1" %}
 								</td>
 								<td class="roomC">TBD</td>
 							</tr>


### PR DESCRIPTION
Jekyll らしくスケジュールのエントリーを YAML のデータから生成するようにしました。
Twitter ハンドルも表示されます。

![scalamatsuri-schedule](https://cloud.githubusercontent.com/assets/184683/11214958/f163e0e4-8d11-11e5-9745-52b00fad6ac6.png)
