### PR TITLE
セッションの説明の dialog が小さい画面に収まるようにする

### DIFF
--- a/js/scalamatsuri2016.js
+++ b/js/scalamatsuri2016.js
@@ -1,13 +1,27 @@
 var scalamatsuri = scalamatsuri || {};
 
 scalamatsuri.displayDescription = function(id) {
+  var w = $(window).width() - 20;
+  var h = $(window).height() - 20;
+  if (w < 0) {
+    w = 10;
+  }
+  if (h < 0) {
+    h = 10;
+  }
+  if (w > 800) {
+    w = 800;
+  }
+  if (h > 600) {
+    h = 600;
+  }
   $("#dialog_message iframe").remove();
   $("#dialog_message").append(
     $("<iframe />").attr("src", "/" + lang + "/candidates/" + id + "/").addClass("schedule_desc")
   ).dialog({
     modal: true,
-    width: 800,
-    height: 600,
+    width: w,
+    height: h,
     buttons: {
       Ok: function() {
         $(this).dialog("close");


### PR DESCRIPTION
今 800x600 で決め打ちしてるので画面が小さいとはみ出ます

![overflow](https://cloud.githubusercontent.com/assets/184683/11317240/1bacfddc-8ff5-11e5-9076-3dd6f0a6367b.png)

`var w = $(window).width() - 20;` にして画面に収まるようにしました。
dialog 出さないで普通の html ページに飛ぶことも考えましたが、それやると戻った時に元のページの位置とタブ状態がリセットされると不便なのでそれを保持する必要があって、それも面倒なので dialog のままにしました。
