### PR TITLE
fix #184

### DIFF
--- a/css/common.css
+++ b/css/common.css
@@ -715,7 +715,7 @@ input, select {
 
 .snsBtnAreaMiddle{
 	padding:0px 0px 40px 0px!important;
-	width:290px!important;
+	width:310px!important;
 	margin:0 auto 0 auto!important;
 }
 


### PR DESCRIPTION
デザインの仕様変更でtweetボタンの横幅が多少広がった(?)ことにより、
4つのボタンの合計のwidthが290pxに収まりきらなくなったせい？

そもそも、なぜ合計を想定して横幅のpxを直値で入れておかないといけない残念な感じになってるのか謎だが、
とりあえずこれで直った
