### PR TITLE
スケジュールのダイアログの改善

### DIFF
--- a/_includes/schedule_en.html
+++ b/_includes/schedule_en.html
@@ -3,8 +3,61 @@
   {% if candidate.relative_path == relative_path %}
     <span class="session_title"><a href="javascript:void(0);" onclick="scalamatsuri.displayDescription('{{include.id}}',
      (function() {/*
-<h1 class=\'session_title\'>{{ candidate.title }}</h1>
+<h1 class='session_title'>{{ candidate.title }}</h1>
 <p>{{ candidate.content }}</p>
+<dl class='dl-horizontal'>
+  <dt>Session length</dt>
+  <dd>
+    {% case candidate.length %}
+    {% when 15 %} 15 minutes
+    {% when 40 %} 40 minutes
+    {% endcase %}
+  </dd>
+
+  <dt>Presented in</dt>
+  <dd>
+    {% case candidate.language %}
+    {% when 'Japanese' %} Japanese
+    {% when 'English' %} English
+    {% endcase %}
+  </dd>
+
+  <dt>Target audience</dt>
+  <dd>
+    {% case candidate.audience %}
+    {% when 'Beginner' %} Beginner: No need to have prior knowledge
+    {% when 'Intermediate' %} Intermediate: Requires a basic knowledge of the area
+    {% when 'Advanced' %} Advanced: For those who are experts in the field
+    {% endcase %}
+  </dd>
+
+  <dt>Speaker</dt>
+  <dd>
+    {% if candidate.icon %}
+      <img src='{{candidate.icon}}' class='icon-mini'>
+    {% endif %}
+
+    {{ candidate.name }}
+
+    {% if candidate.organization %}
+    ({{ candidate.organization}})
+    {% endif %}
+
+    {% if candidate.twitter %}
+    <a class='btn btn-social-icon btn-twitter btn-xs'
+     href='https://twitter.com/{{ candidate.twitter }}' target='_blank'>
+      <i class='fa fa-twitter'></i>
+    </a>
+    {% endif %}
+
+    {% if candidate.github %}
+    <a class='btn btn-social-icon btn-github btn-xs'
+     href='https://github.com/{{ candidate.github }}' target='_blank'>
+      <i class='fa fa-github'></i>
+    </a>
+    {% endif %}
+  </dd>
+</dl>
 */}).toString().match(/(\{\/\*)([^]*)(\*\/\})/)[2].replace(/\n|\r/g, ''));">{{ candidate.title }}</a></span>
     <span class="session_name">
       {% if candidate.icon %}

--- a/_includes/schedule_ja.html
+++ b/_includes/schedule_ja.html
@@ -3,8 +3,61 @@
   {% if candidate.relative_path == relative_path %}
     <span class="session_title"><a href="javascript:void(0);" onclick="scalamatsuri.displayDescription('{{include.id}}',
      (function() {/*
-<h1 class=\'session_title\'>{{ candidate.title }}</h1>
+<h1 class='session_title'>{{ candidate.title }}</h1>
 <p>{{ candidate.content }}</p>
+<dl class='dl-horizontal'>
+  <dt>トークの長さ</dt>
+  <dd>
+    {% case candidate.length %}
+    {% when 15 %} 15分
+    {% when 40 %} 40分
+    {% endcase %}
+  </dd>
+
+  <dt>発表言語</dt>
+  <dd>
+    {% case candidate.language %}
+    {% when 'Japanese' %} 日本語
+    {% when 'English' %} 英語
+    {% endcase %}
+  </dd>
+
+  <dt>聴衆の対象</dt>
+  <dd>
+    {% case candidate.audience %}
+    {% when 'Beginner' %} 初心者: 分野の事前知識を必要としない
+    {% when 'Intermediate' %} 中級者: 分野の基礎は分かるが、細かい所は不安
+    {% when 'Advanced' %} 上級者: 分野に精通している人向けでトークでは入門の話は少なめ
+    {% endcase %}
+  </dd>
+
+  <dt>発表者</dt>
+  <dd>
+    {% if candidate.icon %}
+      <img src='{{candidate.icon}}' class='icon-mini'>
+    {% endif %}
+
+    {{ candidate.name }}
+
+    {% if candidate.organization %}
+    ({{ candidate.organization}})
+    {% endif %}
+
+    {% if candidate.twitter %}
+    <a class='btn btn-social-icon btn-twitter btn-xs'
+     href='https://twitter.com/{{ candidate.twitter }}' target='_blank'>
+      <i class='fa fa-twitter'></i>
+    </a>
+    {% endif %}
+
+    {% if candidate.github %}
+    <a class='btn btn-social-icon btn-github btn-xs'
+     href='https://github.com/{{ candidate.github }}' target='_blank'>
+      <i class='fa fa-github'></i>
+    </a>
+    {% endif %}
+  </dd>
+</dl>
 */}).toString().match(/(\{\/\*)([^]*)(\*\/\})/)[2].replace(/\n|\r/g, ''));">{{ candidate.title }}</a></span>
     <span class="session_name">
       {% if candidate.icon %}

--- a/css/common.css
+++ b/css/common.css
@@ -779,9 +779,20 @@ h1.session_title {
 
 .icon-medium { height: 50px; width: 50px; }
 
-iframe.schedule_desc {
+#dialog_contents {
 	width: 100%;
-	height: 440px;
+	height: 8em;
+	line-height: 1.1em;
+	font-size: 70%;
+	font-family: "Hiragino Kaku Gothic ProN", "メイリオ", Meiryo, sans-serif;
+}
+
+#dialog_contents p {
+	padding-bottom: 0.9em
+}
+
+#dialog_contents h1 {
+	padding-bottom: 0.4em;
 }
 
 @media screen and (max-width: 1024px){
@@ -896,16 +907,28 @@ iframe.schedule_desc {
 
 }
 
+@media screen and (min-width: 700px) {
+  .dl-horizontal dt {
+    float: left;
+    width: 13em;
+    clear: left;
+    text-align: right;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .dl-horizontal dd {
+    margin-left: 15em;
+  }
+}
+
 @media screen and (max-width: 700px){
 
 	.logoArea{
 		padding-top:100px;
 		padding-bottom:80px;
 	}
-
 }
-
-
 
 @media screen and (max-width: 560px){
 

--- a/js/scalamatsuri2016.js
+++ b/js/scalamatsuri2016.js
@@ -9,11 +9,11 @@ scalamatsuri.displayDescription = function(id, raw) {
   if (h < 0) {
     h = 10;
   }
-  if (w > 800) {
-    w = 800;
+  if (w > 600) {
+    w = 600;
   }
-  if (h > 600) {
-    h = 600;
+  if (h > 400) {
+    h = 400;
   }
   $("#dialog_message #dialog_contents").remove();
   $("#dialog_message").append(


### PR DESCRIPTION
ref #330 

昨日の #360 の続きです。昨日は急いでいたのでアブストラクトの題と本文だけ埋め込みましたが、トークの長さなどの情報も表示するようにしました。あと、css を調整してホームページと違和感が無いようにしました。

![scalamatsuri_2016 _scala_](https://cloud.githubusercontent.com/assets/184683/12315940/cbbdbd82-ba4e-11e5-82ff-5868ba205d32.png)
