### PR TITLE
CC0 (著作権の放棄) を CoC本文 に適用する

### DIFF
--- a/en/code-of-conduct/index.html
+++ b/en/code-of-conduct/index.html
@@ -68,7 +68,7 @@ This code of conduct is based on the policy from ScalaMatsuri, which in turn is 
 </blockquote>
 </p>
 <p>
-ScalaMatsuri reserve all rights for CoC Manner Video. If you agree to our code of conduct as shown as above, we permit the use of the video in your conference or meetup.
+Japan Scala Association, Inc reserves all rights for the CoC Manner Video. If you agree to our code of conduct as shown as above, we permit the use of the video in your conference or meetup.
 </p>
 <p>
 We would also appreciate it if you let us know via e-mail to <a href="mailto:info@scalamatsuri.org">info@scalamatsuri.org</a> or tweet with hashtag #ScalaMatsuri.

--- a/en/code-of-conduct/index.html
+++ b/en/code-of-conduct/index.html
@@ -57,11 +57,19 @@ We showed a video for Code of conduct and referee system in ScalaMatsuri 2016 op
 </p>
 <iframe width="560" height="315" src="https://www.youtube.com/embed/lIfOQNTWdxI" frameborder="0" allowfullscreen></iframe>
 
-<h3>For Conference or Meetup Organizers</h3>
+<h3>License and attribution</h3>
 <p>
-As far as you agree with ScalaMatsuri 2016 Code-of-Conduct as shown above, you can show up this video in your conference or meetup.</p>
-
-<p>
-In case you use, we would appreciate it if you notify us via e-mail to <a href="mailto:info@scalamatsuri.org">info@scalamatsuri.org</a> or tweet with hashtag #ScalaMatsuri .
+The text part of this policy is licensed under the <a href="https://creativecommons.org/publicdomain/zero/1.0/">Creative Commons Zero license</a>. Like public domain, no credit and no open licencing of your version is required.
 </p>
-
+<p>
+If you would like to optionally attribute it, you could use the below text and link to http://scalamatsuri.org/:
+<blockquote>
+This code of conduct is based on the policy from ScalaMatsuri, which in turn is based on the example policy from the Geek Feminism wiki, and inspired by PNW Scala, NE Scala, and Scala Days.
+</blockquote>
+</p>
+<p>
+ScalaMatsuri reserve all rights for CoC Manner Video. If you agree to our code of conduct as shown as above, we permit the use of the video in your conference or meetup.
+</p>
+<p>
+We would also appreciate it if you let us know via e-mail to <a href="mailto:info@scalamatsuri.org">info@scalamatsuri.org</a> or tweet with hashtag #ScalaMatsuri.
+</p>

--- a/ja/code-of-conduct/index.html
+++ b/ja/code-of-conduct/index.html
@@ -65,7 +65,7 @@ ScalaMatsuri2016当日には、行動規範とレフェリー制について解�
 </blockquote>
 </p>
 <p>
-行動規範マナー動画に関しましては、ScalaMatsuri が著作権を保持します。ただし、この行動規範に同意してくださる限りにおいて、このビデオをカンファレンスや勉強会­、Meetupなどでご自由に使用して頂いて構いません。
+行動規範マナー動画に関しましては、一般社団法人 Japan Scala Association が著作権を保持します。ただし、この行動規範に同意してくださる限りにおいて、このビデオをカンファレンスや勉強会­、Meetupなどでご自由に使用して頂いて構いません。
 </p>
 <p>
 もしご利用された場合には、 <a href="mailto:info@scalamatsuri.org">info@scalamatsuri.org</a>か、ハッシュタグ #ScalaMatsuri をつけたツイートでご一報くださるととても嬉しいです。

--- a/ja/code-of-conduct/index.html
+++ b/ja/code-of-conduct/index.html
@@ -53,12 +53,20 @@ ScalaMatsuri2016当日には、行動規範とレフェリー制について解�
 </p>
 <iframe width="560" height="315" src="https://www.youtube.com/embed/lIfOQNTWdxI" frameborder="0" allowfullscreen></iframe>
 
-<h3>カンファレンス・勉強会 主催者の方へ</h3>
+<h3>ライセンスと帰属に関して</h3>
 <p>
-この行動規範に同意してくださる限りにおいて、このビデオをカンファレンスや勉強会­、Meetupなどでご自由に使用して頂いて構いません。
-</p> 
+本規範のテキスト部分は <a href="https://creativecommons.org/publicdomain/zero/1.0/">Creative Commons Zero license</a> のもとに公開します。パブリック・ドメイン同様に、派生して作られた規範に一切のクレジット表示やオープンライセンスなどを要求しません。
+</p>
+<p>
+もし、任意に帰属表示をしていただけるならば、http://scalamatsuri.org/ へリンクして以下のようなテキストをお使いください:
+
+<blockquote>
+本規範は ScalaMatsuri の規範に基いています。ScalaMatsuri の規範は Geek Feminism wiki の規範例から派生しており、PNW Scala、NE Scala、および Scala Days の影響を受けています。
+</blockquote>
+</p>
+<p>
+行動規範マナー動画に関しましては、ScalaMatsuri が著作権を保持します。ただし、この行動規範に同意してくださる限りにおいて、このビデオをカンファレンスや勉強会­、Meetupなどでご自由に使用して頂いて構いません。
+</p>
 <p>
 もしご利用された場合には、 <a href="mailto:info@scalamatsuri.org">info@scalamatsuri.org</a>か、ハッシュタグ #ScalaMatsuri をつけたツイートでご一報くださるととても嬉しいです。
 </p>
-
-


### PR DESCRIPTION
https://creativecommons.org/choose/zero/?lang=ja

> CC0を使うことで、あなたは作品について有している著作権やそれに 隣接、関連する権利を全て放棄することができます。例えばあなたの 著作者人格権(それが放棄できる範囲において)、あなたのパブリシティ権や プライバシー権、あなたが不正競争から保護される権利、データベース権、 データの取得・流通・再利用を防止する諸権利などが含まれます。

いわゆる「パブリック・ドメイン」が各国ばらばらなので、それに代わる形で全権放棄するライセンスが CC0 です。CoC 原版 (geekfeminism) も CC0 です。
